### PR TITLE
Added missing contrib package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,15 @@ def get_version(version):
     """
     assert len(version) == 5
     assert version[3] in ('alpha', 'beta', 'rc', 'final')
-    
+
     parts = 2 if version[2] == 0 else 3
     main = '.'.join(str(x) for x in version[:parts])
-    
+
     sub = ''
     if version[3] != 'final':
         mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'c'}
         sub = mapping[version[3]] + str(version[4])
-    
+
     return main + sub
 
 
@@ -36,27 +36,28 @@ setup(
     description='Awesome Django authorization, without the database',
     version=get_version(VERSION),
     long_description=long_description,
-    
+
     url='http://github.com/dfunckt/django-rules',
     author='Akis Kesoglou',
     author_email='akiskesoglou@gmail.com',
     maintainer='Akis Kesoglou',
     maintainer_email='akiskesoglou@gmail.com',
     license='MIT',
-    
+
     zip_safe=False,
     packages=[
         'rules',
         'rules.templatetags',
+        'rules.contrib',
     ],
-    
+
     install_requires=[
         # 'Django >= 1.5',
     ],
     tests_require=[
         'nose',
     ],
-    
+
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
The contrib package was missing in setup.py.
I was always getting "ImportError: No module named contrib.admin" when trying to setup the Django admin.
