### PR TITLE
toxify the project

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = {py26,py27,py32,py33,py34,pypy,pypy3}
+
+[testenv]
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py32: python3.2
+    py33: python3.3
+    py34: python3.3
+    pypy: pypy
+    pypy3: pypy3
+
+deps =
+    nose
+
+commands = nosetests {posargs}


### PR DESCRIPTION
To ease testing on all targeted python versions.
