### PR TITLE
Predicate call context (WIP)

### DIFF
--- a/rules/permissions.py
+++ b/rules/permissions.py
@@ -16,16 +16,16 @@ def perm_exists(name):
     return permissions.rule_exists(name)
 
 
-def has_perm(name, obj=None, target=None):
-    return permissions.test_rule(name, obj, target)
+def has_perm(name, *args, **kwargs):
+    return permissions.test_rule(name, *args, **kwargs)
 
 
 class ObjectPermissionBackend(object):
     def authenticate(self, username, password):
         return None
 
-    def has_perm(self, user, perm, obj=None):
-        return has_perm(perm, user, obj)
+    def has_perm(self, user, perm, *args, **kwargs):
+        return has_perm(perm, user, *args, **kwargs)
 
     def has_module_perms(self, user, app_label):
         return has_perm(app_label, user)

--- a/rules/predicates.py
+++ b/rules/predicates.py
@@ -30,7 +30,7 @@ del NoValueSentinel
 
 
 class Predicate(object):
-    def __init__(self, fn, name=None):
+    def __init__(self, fn, name=None, bind=False):
         # fn can be a callable with any of the following signatures:
         #   - fn(obj=None, target=None)
         #   - fn(obj=None)
@@ -59,11 +59,14 @@ class Predicate(object):
             name = name or type(fn).__name__
         else:
             raise TypeError('Incompatible predicate.')
+        if bind:
+            num_args -= 1
         assert num_args <= 2, 'Incompatible predicate.'
         self.fn = fn
         self.num_args = num_args
         self.var_args = var_args
         self.name = name or fn.__name__
+        self.bind = bind
 
     def __repr__(self):
         return '<%s:%s object at %s>' % (
@@ -77,6 +80,8 @@ class Predicate(object):
         # underlying callable's signature that was most likely decorated
         # as a predicate. internally we consistently call ``_apply`` that
         # provides a single interface to the callable.
+        if self.bind:
+            return self.fn(self, *args, **kwargs)
         return self.fn(*args, **kwargs)
 
     @property
@@ -161,10 +166,12 @@ class Predicate(object):
             callargs = args + (None,) * (self.num_args - len(args))
         else:
             callargs = args[:self.num_args]
+        if self.bind:
+            return bool(self.fn(self, *callargs))
         return bool(self.fn(*callargs))
 
 
-def predicate(fn=None, name=None):
+def predicate(fn=None, name=None, bind=False):
     """
     Decorator that constructs a ``Predicate`` instance from any function::
 
@@ -172,6 +179,11 @@ def predicate(fn=None, name=None):
         ... def is_book_author(user, book):
         ...     return user == book.author
         ...
+
+        >>> @predicate(bind=True)
+        ... def is_book_author(self, user, book):
+        ...     if self.context.args:
+        ...         return user == book.author
     """
     if not name and not callable(fn):
         name = fn
@@ -180,7 +192,7 @@ def predicate(fn=None, name=None):
     def inner(fn):
         if isinstance(fn, Predicate):
             return fn
-        p = Predicate(fn, name)
+        p = Predicate(fn, name, bind=bind)
         if isinstance(fn, partial):
             update_wrapper(p, fn.func)
         else:

--- a/rules/rulesets.py
+++ b/rules/rulesets.py
@@ -2,8 +2,8 @@ from .predicates import predicate
 
 
 class RuleSet(dict):
-    def test_rule(self, name, obj=None, target=None):
-        return name in self and self[name].test(obj, target)
+    def test_rule(self, name, *args, **kwargs):
+        return name in self and self[name].test(*args, **kwargs)
 
     def rule_exists(self, name):
         return name in self
@@ -38,5 +38,5 @@ def rule_exists(name):
     return default_rules.rule_exists(name)
 
 
-def test_rule(name, obj=None, target=None):
-    return default_rules.test_rule(name, obj, target)
+def test_rule(name, *args, **kwargs):
+    return default_rules.test_rule(name, *args, **kwargs)

--- a/tests/testsuite/test_predicates.py
+++ b/tests/testsuite/test_predicates.py
@@ -319,3 +319,11 @@ def test_invocation_context_storage():
 
     p = p1 & p2
     assert p.test('a')
+
+
+def test_binding_predicate():
+    @predicate(bind=True)
+    def is_bound(self):
+        return self is is_bound
+
+    assert is_bound()


### PR DESCRIPTION
Related to #6, #7, #9.

Adds the ability to specify that a predicate wants a dict containing information about the current ``test_rule()`` invocation.

```
>>> @rules.predicate(takes_context=True)
... def mypred(a, b, **kwargs):
...    print(kwargs['context'])
...    return True
...
>>> rules.add_rule('myrule', mypred)
>>> rules.test_rule('myrule', 1, 2)
{'args': (1, 2), 'kwargs': {}}
True
```

Predicates that want context must accept ``**kwargs``.

A nice advantage of this PR is that it allows predicates to store arbitrary data that other predicates may later use. It is possible for example, to store an expensive computation done in one predicate (maybe fetch a bunch of objects from db, related to the given user/object) and another predicate access it later on.

This is backwards-compatible -- at least all tests pass.

Here are some things that need to be done in order for this PR to be merged:

- [ ] Decide on the API -- pretty close already, I guess.
- [ ] Write docs -- add a new section in README for now.
- [ ] Find any glaring bugs.
- [ ] Some more tests maybe.

All feedback welcome.