### PR TITLE
Allow instance methods as predicates

### DIFF
--- a/rules/predicates.py
+++ b/rules/predicates.py
@@ -13,7 +13,11 @@ class Predicate(object):
             fn, num_args, name = fn.fn, fn.num_args, name or fn.name
         elif isinstance(fn, partial):
             num_args = len(inspect.getargspec(fn.func).args) - len(fn.args)
+            if inspect.ismethod(fn.func):
+                num_args -= 1  # skip `self`
             name = fn.func.__name__
+        elif inspect.ismethod(fn):
+            num_args = len(inspect.getargspec(fn).args) - 1  # skip `self`
         elif inspect.isfunction(fn):
             num_args = len(inspect.getargspec(fn).args)
         elif isinstance(fn, object):

--- a/tests/testsuite/test_predicates.py
+++ b/tests/testsuite/test_predicates.py
@@ -48,6 +48,28 @@ def test_partial_function_predicate():
     assert p(3)
 
 
+def test_method_predicate():
+    class SomeClass(object):
+        def some_method(self, arg1, arg2):
+            return arg1 == arg2
+    obj = SomeClass()
+    p = Predicate(obj.some_method)
+    assert p.name == 'some_method'
+    assert p.num_args == 2
+    assert p(2, 2)
+
+
+def test_partial_method_predicate():
+    class SomeClass(object):
+        def some_method(self, arg1, arg2):
+            return arg1 == arg2
+    obj = SomeClass()
+    p = Predicate(functools.partial(obj.some_method, 2))
+    assert p.name == 'some_method'
+    assert p.num_args == 1
+    assert p(2)
+
+
 def test_class_predicate():
     class callableclass(object):
         def __call__(self, arg1, arg2):


### PR DESCRIPTION
This came up when I was trying to use Django model methods as predicates.