### PR TITLE
Add logging to predicates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -633,6 +633,7 @@ Complex or heavily nested rules can be painful to debug. This package provides a
 This is a basic configuration (place in your `settings.py`):
 
 .. code:: python
+
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Features
     works.
 -   **Powerful**. ``rules`` comes complete with advanced features, such as
     invocation context and storage for arbitrary data, skipping evaluation of
-    predicates under specific conditions, and more!
+    predicates under specific conditions, logging of evaluated predicates and more!
 
 
 Table of Contents
@@ -59,6 +59,7 @@ Table of Contents
   - `Invocation context`_
   - `Binding "self"`_
   - `Skipping predicates`_
+  - `Logging predicate evaluation`_
 
 - `Best practices`_
 - `API Reference`_
@@ -622,6 +623,36 @@ leaving the predicate result up to that point unchanged.
 **Note:** This is new in version 1.1.0. It was possible to skip predicates in
 older versions by calling the predicate's ``skip()`` method, but this has been
 deprecated and support will be completely removed in a future version.
+
+
+Logging predicate evaluation
+----------------------------
+
+Complex or heavily nested rules can be painful to debug. This package provides a `django-rules` logger that can be configured in your django settings to output the results of individual evaluations to the console. Messages are sent at the `DEBUG` level.
+
+This is a basic configuration (place in your `settings.py`):
+
+.. code:: python
+    LOGGING = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+            },
+        },
+        'loggers': {
+            'django-rules': {
+                'handlers': ['console'],
+                'level': 'DEBUG',
+                'propagate': True,
+            },
+        },
+    }
+
+When this logger is active each individual predicate will have a log message printed when it is evaluated.
+
 
 Best practices
 ==============

--- a/README.rst
+++ b/README.rst
@@ -628,9 +628,10 @@ deprecated and support will be completely removed in a future version.
 Logging predicate evaluation
 ----------------------------
 
-Complex or heavily nested rules can be painful to debug. This package provides a `django-rules` logger that can be configured in your django settings to output the results of individual evaluations to the console. Messages are sent at the `DEBUG` level.
-
-This is a basic configuration (place in your `settings.py`):
+rules can optionally be configured to log debug information as rules are
+evaluated to help with debugging your predicates. Messages are sent at the
+DEBUG level to the `rules` logger. The following dictConfig configures the
+logger to log to the console (place in your `settings.py`): 
 
 .. code:: python
 
@@ -644,7 +645,7 @@ This is a basic configuration (place in your `settings.py`):
             },
         },
         'loggers': {
-            'django-rules': {
+            'rules': {
                 'handlers': ['console'],
                 'level': 'DEBUG',
                 'propagate': True,

--- a/rules/predicates.py
+++ b/rules/predicates.py
@@ -6,7 +6,7 @@ from functools import partial, update_wrapper
 from warnings import warn
 
 
-logger = logging.getLogger('django-rules')
+logger = logging.getLogger('rules')
 
 
 class SkipPredicate(Exception):
@@ -216,12 +216,13 @@ class Predicate(object):
             callargs = (self,) + callargs
         try:
             result = self.fn(*callargs)
-            returner = None if result is None else bool(result)
+            if result is not None:
+                result = bool(result)
         except SkipPredicate:
-            returner = None
+            result = None
         
-        logger.debug('%s = %s', self, 'skipped' if returner is None else returner)
-        return returner
+        logger.debug('  %s = %s', self, 'skipped' if result is None else result)
+        return result
 
 
 def predicate(fn=None, name=None, **options):

--- a/rules/predicates.py
+++ b/rules/predicates.py
@@ -1,8 +1,12 @@
 import inspect
 import operator
 import threading
+import logging
 from functools import partial, update_wrapper
 from warnings import warn
+
+
+logger = logging.getLogger('django-rules')
 
 
 class SkipPredicate(Exception):
@@ -150,6 +154,7 @@ class Predicate(object):
         """
         args = tuple(arg for arg in (obj, target) if arg is not NO_VALUE)
         _context.stack.append(Context(args))
+        logger.info('Testing %s', self)
         try:
             return bool(self._apply(*args))
         finally:
@@ -211,7 +216,9 @@ class Predicate(object):
             callargs = (self,) + callargs
         try:
             result = self.fn(*callargs)
-            return None if result is None else bool(result)
+            returner = None if result is None else bool(result)
+            logger.info('%s = %s', self, returner)
+            return returner
         except SkipPredicate:
             return None
 

--- a/rules/predicates.py
+++ b/rules/predicates.py
@@ -217,10 +217,11 @@ class Predicate(object):
         try:
             result = self.fn(*callargs)
             returner = None if result is None else bool(result)
-            logger.info('%s = %s', self, returner)
-            return returner
         except SkipPredicate:
-            return None
+            returner = None
+        
+        logger.info('%s = %s', self, 'skipped' if returner is None else returner)
+        return returner
 
 
 def predicate(fn=None, name=None, **options):

--- a/rules/predicates.py
+++ b/rules/predicates.py
@@ -154,7 +154,7 @@ class Predicate(object):
         """
         args = tuple(arg for arg in (obj, target) if arg is not NO_VALUE)
         _context.stack.append(Context(args))
-        logger.info('Testing %s', self)
+        logger.debug('Testing %s', self)
         try:
             return bool(self._apply(*args))
         finally:
@@ -220,7 +220,7 @@ class Predicate(object):
         except SkipPredicate:
             returner = None
         
-        logger.info('%s = %s', self, 'skipped' if returner is None else returner)
+        logger.debug('%s = %s', self, 'skipped' if returner is None else returner)
         return returner
 
 

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -58,3 +58,21 @@ TEMPLATES = [
         },
     },
 ]
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django-rules': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    },
+}

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -64,14 +64,14 @@ LOGGING = {
     'disable_existing_loggers': False,
     'handlers': {
         'console': {
-            'level': 'INFO',
+            'level': 'DEBUG',
             'class': 'logging.StreamHandler',
         },
     },
     'loggers': {
         'django-rules': {
             'handlers': ['console'],
-            'level': 'INFO',
+            'level': 'DEBUG',
             'propagate': True,
         },
     },

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -58,21 +58,3 @@ TEMPLATES = [
         },
     },
 ]
-
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'level': 'DEBUG',
-            'class': 'logging.StreamHandler',
-        },
-    },
-    'loggers': {
-        'django-rules': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-    },
-}


### PR DESCRIPTION
One thing that would be really helpful as you're developing an app that uses django-rules is to have some form of logging output as to the results of nested predicates.

For example in our app we have some fairly complex predicates that are nested, and if the whole chain returns `False` it would be handy to know exactly what triggered that without having to dive into all of the interactions in our `rules.py`. 

This MR adds initial support for this, it will need some more work but please let me know if you think I should spend more time fleshing this out.

The logging output looks like this when running the test suite:
```
Testing ((requires_two_args & requires_two_args) & passthrough)
requires_two_args = skipped
requires_two_args = skipped
(requires_two_args & requires_two_args) = skipped
passthrough = True
((requires_two_args & requires_two_args) & passthrough) = True
```

And

```
Testing (passthrough | ~requires_two_args)
passthrough = True
(passthrough | ~requires_two_args) = True
```

Edit: I didn't handle skipped predicates, I added a commit to do this.
