### PR TITLE
Removed Python 2.6,3.3 & Django <1.8,1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs/_build
 pip-log.txt
 .tox
 .eggs/
+.idea/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
-  - "pypy3"
 env:
   - DJANGO='Django<1.9'  # Django 1.8
   - DJANGO='Django<1.11' # Django 1.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,24 @@
 # ----------------------------------------
 # Python support matrix per Django version
 #
-#   2.6   1.5  1.6
 #   2.7   1.5  1.6  1.7  1.8  1.9  1.10
-#   3.3   1.5  1.6  1.7  1.8
 #   3.4             1.7  1.8  1.9  1.10
 #   3.5                  1.8  1.9  1.10
 # ----------------------------------------
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
   - "pypy3"
 env:
-  - DJANGO='Django<1.6'  # Django 1.5
-  - DJANGO='Django<1.7'  # Django 1.6
-  - DJANGO='Django<1.8'  # Django 1.7
   - DJANGO='Django<1.9'  # Django 1.8
-  - DJANGO='Django<1.10' # Django 1.9
   - DJANGO='Django<1.11' # Django 1.10
 matrix:
   exclude:
-    - python: "2.6"
-      env: DJANGO='Django<1.8'
-    - python: "2.6"
-      env: DJANGO='Django<1.9'
-    - python: "2.6"
-      env: DJANGO='Django<1.10'
-    - python: "2.6"
-      env: DJANGO='Django<1.11'
-    - python: "3.3"
-      env: DJANGO='Django<1.10'
-    - python: "3.3"
-      env: DJANGO='Django<1.11'
-    - python: "3.4"
-      env: DJANGO='Django<1.6'
-    - python: "3.4"
-      env: DJANGO='Django<1.7'
-    - python: "3.5"
-      env: DJANGO='Django<1.6'
-    - python: "3.5"
-      env: DJANGO='Django<1.7'
-    - python: "3.5"
-      env: DJANGO='Django<1.8'
     - python: "pypy3"
       env: DJANGO='Django<1.10'
     - python: "pypy3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 #   2.7   1.5  1.6  1.7  1.8  1.9  1.10
 #   3.4             1.7  1.8  1.9  1.10
 #   3.5                  1.8  1.9  1.10
+#   3.6                  1.8  1.9  1.10
 # ----------------------------------------
 sudo: false
 language: python
@@ -17,12 +18,6 @@ python:
 env:
   - DJANGO='Django<1.9'  # Django 1.8
   - DJANGO='Django<1.11' # Django 1.10
-matrix:
-  exclude:
-    - python: "pypy3"
-      env: DJANGO='Django<1.10'
-    - python: "pypy3"
-      env: DJANGO='Django<1.11'
 install:
   - 'pip install "${DJANGO}"'
   - pip install coveralls

--- a/README.rst
+++ b/README.rst
@@ -77,8 +77,8 @@ Table of Contents
 Requirements
 ============
 
-``rules`` requires Python 2.6/3.3 or newer. It can optionally integrate with
-Django, in which case requires Django 1.5 or newer.
+``rules`` requires Python 2.7/3.4 or newer. It can optionally integrate with
+Django, in which case requires Django 1.8 or newer.
 
 
 How to install
@@ -451,7 +451,7 @@ You can customise the object either by overriding ``get_object`` or
 For more information refer to the `Django documentation`_ and the
 ``rules.contrib.views`` module.
 
-.. _Django documentation: https://docs.djangoproject.com/en/1.9/topics/auth/default/#limiting-access-to-logged-in-users
+.. _Django documentation: https://docs.djangoproject.com/en/1.10/topics/auth/default/#limiting-access-to-logged-in-users
 
 Rules and permissions in templates
 ----------------------------------
@@ -708,7 +708,7 @@ On the other hand, because importing predicates from all over the place in
 order to define rules can lead to circular imports and broken hearts, it's
 best to further split predicates and rules in different modules.
 
-If using Django 1.7 and later, ``rules`` may optionally be configured to
+``rules`` may optionally be configured to
 autodiscover ``rules.py`` modules in your apps and import them at startup. To
 have ``rules`` do so, just edit your ``INSTALLED_APPS`` setting:
 

--- a/rules/contrib/admin.py
+++ b/rules/contrib/admin.py
@@ -1,11 +1,5 @@
 from django.contrib import admin
-
-try:
-    from django.contrib.auth import get_permission_codename
-except ImportError:  # pragma: no cover
-    # Django < 1.6
-    def get_permission_codename(action, opts):
-        return '%s_%s' % (action, opts.object_name.lower())
+from django.contrib.auth import get_permission_codename
 
 
 class ObjectPermissionsModelAdminMixin(object):

--- a/runtests.py
+++ b/runtests.py
@@ -16,13 +16,8 @@ def main():
 
     environ['DJANGO_SETTINGS_MODULE'] = 'testapp.settings'
 
-    try:
-        # django >= 1.7
-        from django import setup
-    except ImportError:
-        pass
-    else:
-        setup()
+    from django import setup
+    setup()
 
     # setup test env
     from django.test.utils import setup_test_environment
@@ -34,10 +29,7 @@ def main():
         'interactive': False,
         'verbosity': 1,
     }
-    try:
-        call_command('migrate', **options)
-    except CommandError:  # Django < 1.7
-        call_command('syncdb', **options)
+    call_command('migrate', **options)
 
     # run tests
     return nose.main()

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     tests_require=[
         'nose',
         'coverage',
-        'Django >= 1.5',
+        'Django >= 1.8',
     ],
 
     classifiers=[
@@ -69,10 +69,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,16 @@
 [tox]
 envlist =
-    {py26}-django{15,16},
-    {py27}-django{15,16,17,18,19,110},
-    {py33}-django{15,16,17,18},
-    {py34}-django{17,18,19,110},
-    {py35}-django{18,19,110},
-    {pypy}-django{15,16,17,18,19,110},
-    {pypy3}-django{15,16,17,18}
+    {py27}-django{18,110},
+    {py34}-django{18,110},
+    {py35}-django{18,110},
+    {py36}-django{18,110},
+    {pypy}-django{18,110},
+    {pypy3}-django{18,110}
 
 [testenv]
 deps =
     nose
-    django15: Django>=1.5,<1.6
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist =
     {py35}-django{18,110},
     {py36}-django{18,110},
     {pypy}-django{18,110},
-    {pypy3}-django{18,110}
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 2.6 and 3.3 are no longer supported.  Django <1.8 and 1.9 are no longer supported.