### PR TITLE
Add Travis and tox config for Django 1.11 and Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@
 # Python support matrix per Django version
 #
 #   2.6   1.5  1.6
-#   2.7   1.5  1.6  1.7  1.8  1.9  1.10
+#   2.7   1.5  1.6  1.7  1.8  1.9  1.10  1.11
 #   3.3   1.5  1.6  1.7  1.8
-#   3.4             1.7  1.8  1.9  1.10
-#   3.5                  1.8  1.9  1.10
+#   3.4             1.7  1.8  1.9  1.10  1.11
+#   3.5                  1.8  1.9  1.10  1.11
+#   3.6                            1.10  1.11
 # ----------------------------------------
 sudo: false
 language: python
@@ -24,6 +25,7 @@ env:
   - DJANGO='Django<1.9'  # Django 1.8
   - DJANGO='Django<1.10' # Django 1.9
   - DJANGO='Django<1.11' # Django 1.10
+  - DJANGO='Django<1.12' # Django 1.11
 matrix:
   exclude:
     - python: "2.6"
@@ -34,10 +36,14 @@ matrix:
       env: DJANGO='Django<1.10'
     - python: "2.6"
       env: DJANGO='Django<1.11'
+    - python: "2.6"
+      env: DJANGO='Django<1.12'
     - python: "3.3"
       env: DJANGO='Django<1.10'
     - python: "3.3"
       env: DJANGO='Django<1.11'
+    - python: "3.3"
+      env: DJANGO='Django<1.12'
     - python: "3.4"
       env: DJANGO='Django<1.6'
     - python: "3.4"
@@ -48,10 +54,22 @@ matrix:
       env: DJANGO='Django<1.7'
     - python: "3.5"
       env: DJANGO='Django<1.8'
+    - python: "3.6"
+      env: DJANGO='Django<1.6'
+    - python: "3.6"
+      env: DJANGO='Django<1.7'
+    - python: "3.6"
+      env: DJANGO='Django<1.8'
+    - python: "3.6"
+      env: DJANGO='Django<1.9'
+    - python: "3.6"
+      env: DJANGO='Django<1.10'
     - python: "pypy3"
       env: DJANGO='Django<1.10'
     - python: "pypy3"
       env: DJANGO='Django<1.11'
+    - python: "pypy3"
+      env: DJANGO='Django<1.12'
 install:
   - 'pip install "${DJANGO}"'
   - pip install coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist =
     {py26}-django{15,16},
-    {py27}-django{15,16,17,18,19,110},
+    {py27}-django{15,16,17,18,19,110,111},
     {py33}-django{15,16,17,18},
-    {py34}-django{17,18,19,110},
-    {py35}-django{18,19,110},
-    {pypy}-django{15,16,17,18,19,110},
+    {py34}-django{17,18,19,110,111},
+    {py35}-django{18,19,110,111},
+    {py36}-django{110,111},
+    {pypy}-django{15,16,17,18,19,110,111},
     {pypy3}-django{15,16,17,18}
 
 [testenv]
@@ -17,6 +18,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
 
 commands =
     {envbindir}/python runtests.py --nologcapture --nocapture {posargs}


### PR DESCRIPTION
Fixes #60 

I think the Travis CI config is confusing, consider switching to tox-travis and run tox in travis. For an example, see https://github.com/dyve/django-bootstrap3/blob/develop/.travis.yml