### PR TITLE
Make Django2.0 compatible: use simple_tag, closes #69

### DIFF
--- a/rules/templatetags/rules.py
+++ b/rules/templatetags/rules.py
@@ -4,14 +4,15 @@ from ..rulesets import default_rules
 
 
 register = template.Library()
+register_tag = register.assignment_tag if hasattr(register, 'assignment_tag') else register.simple_tag
 
 
-@register.assignment_tag
+@register_tag
 def test_rule(name, obj=None, target=None):
     return default_rules.test_rule(name, obj, target)
 
 
-@register.assignment_tag
+@register_tag
 def has_perm(perm, user, obj=None):
     if not hasattr(user, 'has_perm'):  # pragma: no cover
         return False  # swapped user model that doesn't support permissions


### PR DESCRIPTION
I saw the previous discussion on #65, and while I agree that dropping versions and other major changes should have to wait, I'm anxious to move to Django 2.0, and as long as this involves only a few corrected imports, I'd be really happy if you'd decide to merge this PR and make a patch release.