### PR TITLE
Update rules and perms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -796,7 +796,7 @@ Instance methods
 
 ``update_rule(name)``
     Update the rule with the given name. Raises ``KeyError`` if no rule with
-    that name exist.
+    that name exists.
 
 ``rule_exists(name)``
     Returns ``True`` if a rule with the given name exists, ``False`` otherwise.

--- a/README.rst
+++ b/README.rst
@@ -267,12 +267,7 @@ We can now update our ``can_edit_book`` rule:
 
 .. code:: python
 
-    >>> rules.add_rule('can_edit_book', is_book_author_or_editor)
-    Traceback (most recent call last):
-        ...
-    KeyError: A rule with name `can_edit_book` already exists
-    >>> rules.remove_rule('can_edit_book')
-    >>> rules.add_rule('can_edit_book', is_book_author_or_editor)
+    >>> rules.update_rule('can_edit_book', is_book_author_or_editor)
     >>> rules.test_rule('can_edit_book', adrian, guidetodjango)
     True
     >>> rules.test_rule('can_delete_book', adrian, guidetodjango)

--- a/README.rst
+++ b/README.rst
@@ -794,6 +794,10 @@ Instance methods
     Remove the rule with the given name. Raises ``KeyError`` if a rule with
     that name does not exist.
 
+``update_rule(name)``
+    Update the rule with the given name. Raises ``KeyError`` if no rule with
+    that name exist.
+
 ``rule_exists(name)``
     Returns ``True`` if a rule with the given name exists, ``False`` otherwise.
 
@@ -881,6 +885,10 @@ Managing the shared rule set
 ``remove_rule(name)``
     Remove a rule from the shared rule set. See ``RuleSet.remove_rule``.
 
+``update_rule(name)``
+    Update the rule with the given name from the shared rules. Raises ``KeyError`` if no rule with
+    that name exists. See ``RuleSet.update_rule``.
+
 ``rule_exists(name)``
     Returns whether a rule exists in the shared rule set. See
     ``RuleSet.rule_exists``.
@@ -897,6 +905,9 @@ Managing the permissions rule set
 
 ``remove_perm(name)``
     Remove a rule from the permissions rule set. See ``RuleSet.remove_rule``.
+
+``update_perm(name)``
+    Update a rule from the permissions rule set. See ``RuleSet.update_rule``.
 
 ``perm_exists(name)``
     Returns whether a rule exists in the permissions rule set. See

--- a/rules/permissions.py
+++ b/rules/permissions.py
@@ -12,6 +12,10 @@ def remove_perm(name):
     permissions.remove_rule(name)
 
 
+def update_perm(name, pred):
+    permissions.update_rule(name, pred)
+
+
 def perm_exists(name):
     return permissions.rule_exists(name)
 

--- a/rules/rulesets.py
+++ b/rules/rulesets.py
@@ -16,6 +16,11 @@ class RuleSet(dict):
     def remove_rule(self, name):
         del self[name]
 
+    def update_rule(self, name, pred):
+        if not name in self:
+            raise KeyError('No rule with name `%s` exists' % name)
+        self[name] = pred
+
     def __setitem__(self, name, pred):
         fn = predicate(pred)
         super(RuleSet, self).__setitem__(name, fn)
@@ -32,6 +37,10 @@ def add_rule(name, pred):
 
 def remove_rule(name):
     default_rules.remove_rule(name)
+
+
+def update_rule(name, pred):
+    default_rules.update_rule(name, pred)
 
 
 def rule_exists(name):

--- a/tests/testsuite/test_rulesets.py
+++ b/tests/testsuite/test_rulesets.py
@@ -32,7 +32,7 @@ def test_shared_ruleset():
     assert test_rule('somerule')
     update_rule('somerule', always_false)
     assert not test_rule('somerule')
-    assert_raises(KeyError, update_rule, 'someoterrule', always_false)
+    assert_raises(KeyError, update_rule, 'someotherrule', always_false)
     remove_rule('somerule')
     assert not rule_exists('somerule')
 

--- a/tests/testsuite/test_rulesets.py
+++ b/tests/testsuite/test_rulesets.py
@@ -2,7 +2,7 @@ from nose.tools import nottest, with_setup, assert_raises
 
 from rules.predicates import predicate
 from rules.rulesets import (RuleSet, default_rules, add_rule, remove_rule,
-                            rule_exists, test_rule)
+                            update_rule, rule_exists, test_rule)
 
 
 test_rule = nottest(test_rule)
@@ -19,6 +19,10 @@ def reset_ruleset(ruleset):
 def always_true():
     return True
 
+@predicate
+def always_false():
+    return False
+
 
 @with_setup(reset_ruleset(default_rules), reset_ruleset(default_rules))
 def test_shared_ruleset():
@@ -26,6 +30,9 @@ def test_shared_ruleset():
     assert 'somerule' in default_rules
     assert rule_exists('somerule')
     assert test_rule('somerule')
+    update_rule('somerule', always_false)
+    assert not test_rule('somerule')
+    assert_raises(KeyError, update_rule, 'someoterrule', always_false)
     remove_rule('somerule')
     assert not rule_exists('somerule')
 
@@ -37,5 +44,8 @@ def test_ruleset():
     assert ruleset.rule_exists('somerule')
     assert ruleset.test_rule('somerule')
     assert_raises(KeyError, ruleset.add_rule, 'somerule', always_true)
+    ruleset.update_rule('somerule', always_false)
+    assert not test_rule('somerule')
+    assert_raises(KeyError, ruleset.update_rule, 'someotherrule', always_false)
     ruleset.remove_rule('somerule')
     assert not ruleset.rule_exists('somerule')


### PR DESCRIPTION
Added functions to update rules and perms, without having to delete first and then add them. Small change, but reduces the amount of lines of code necessary.