### PR TITLE
Remove available_attrs import, update shims for Django 3.0

### DIFF
--- a/rules/contrib/views.py
+++ b/rules/contrib/views.py
@@ -6,7 +6,6 @@ from django.contrib.auth import mixins
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied, ImproperlyConfigured, FieldError
 from django.shortcuts import get_object_or_404
-from django.utils.decorators import available_attrs
 from django.utils.encoding import force_text
 from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -4,7 +4,12 @@ import sys
 
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    def python_2_unicode_compatible(c):
+        return c
 
 import rules
 


### PR DESCRIPTION
Thanks for maintaining this library! I noticed that `rules` is still broken on Django 3.0 because `available_attrs` is imported even though it isn't used after the changes in #97. I also added a shim for the `python_2_unicode_compatible` decorator in the tests.