### PR TITLE
Remove Django 3.0 incompatible import

### DIFF
--- a/rules/contrib/views.py
+++ b/rules/contrib/views.py
@@ -6,7 +6,6 @@ from django.contrib.auth import mixins
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied, ImproperlyConfigured, FieldError
 from django.shortcuts import get_object_or_404
-from django.utils.decorators import available_attrs
 from django.utils.encoding import force_text
 from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
 


### PR DESCRIPTION
We forgot to drop the import in a461428. Closes #111.