### PR TITLE
Drop cache step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-
     - name: Install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --upgrade coveralls tox tox-py tox-venv


### PR DESCRIPTION
based on https://github.com/dfunckt/django-rules/commit/6d46dee31eb55d91bcc539489c9d2944cd57d1de#r50439350

at the moment not much benefit from it, sorry about that