### PR TITLE
update AppConfig for Django 4.1

### DIFF
--- a/rules/__init__.py
+++ b/rules/__init__.py
@@ -22,5 +22,3 @@ from .rulesets import (  # noqa
 )
 
 VERSION = (3, 0, 0, "final", 1)
-
-default_app_config = "rules.apps.RulesConfig"

--- a/rules/apps.py
+++ b/rules/apps.py
@@ -3,9 +3,12 @@ from django.apps import AppConfig
 
 class RulesConfig(AppConfig):
     name = "rules"
+    default = True
 
 
 class AutodiscoverRulesConfig(RulesConfig):
+    default = False
+
     def ready(self):
         from django.utils.module_loading import autodiscover_modules
 


### PR DESCRIPTION
Getting the following warning on Django 3.2:

```
RemovedInDjango41Warning: 'rules' defines default_app_config = 'rules.apps.RulesConfig'. However, Django's automatic detection did not find this configuration. You should move the default config class to the apps submodule of your application and, if this module defines several config classes, mark the default one with default = True.
```

I *hope* that I've made the update correctly - I'm not sure if the test suite covers both app configs...

I also wasn't sure if libraries are supposed to keep the old `default_app_config` variable around for backwards-compatibility and whether or not correctly declaring `default = True` on the relevant app config is enough to silence this warning with `default_app_config` still set.