### PR TITLE
Add `verbose_name` for rules and permissions

### DIFF
--- a/rules/contrib/models.py
+++ b/rules/contrib/models.py
@@ -36,7 +36,10 @@ class RulesModelBaseMixin:
         new_class._meta.rules_permissions = perms
         new_class.preprocess_rules_permissions(perms)
         for perm_type, predicate in perms.items():
-            add_perm(new_class.get_perm(perm_type), predicate)
+            if isinstance(predicate, dict):
+                add_perm(new_class.get_perm(perm_type), predicate['pred'], verbose_name=predicate['verbose_name'])
+            else:
+                add_perm(new_class.get_perm(perm_type), predicate)
         return new_class
 
 

--- a/rules/permissions.py
+++ b/rules/permissions.py
@@ -3,12 +3,12 @@ from .rulesets import RuleSet
 permissions = RuleSet()
 
 
-def add_perm(name, pred):
-    permissions.add_rule(name, pred)
+def add_perm(name, pred, verbose_name=None):
+    permissions.add_rule(name, pred, verbose_name=verbose_name)
 
 
-def set_perm(name, pred):
-    permissions.set_rule(name, pred)
+def set_perm(name, pred, verbose_name=None):
+    permissions.set_rule(name, pred, verbose_name=verbose_name)
 
 
 def remove_perm(name):
@@ -17,6 +17,10 @@ def remove_perm(name):
 
 def perm_exists(name):
     return permissions.rule_exists(name)
+
+
+def perm_verbose_name(name):
+    return permissions.rule_verbose_name(name)
 
 
 def has_perm(name, *args, **kwargs):

--- a/rules/predicates.py
+++ b/rules/predicates.py
@@ -242,7 +242,10 @@ def predicate(fn=None, name=None, **options):
         ...     if self.context.args:
         ...         return user == book.author
     """
-    if not name and not callable(fn):
+    
+    if type(fn) is dict:
+        fn = fn['pred']
+    elif not name and not callable(fn):
         name = fn
         fn = None
 

--- a/rules/rulesets.py
+++ b/rules/rulesets.py
@@ -3,25 +3,28 @@ from .predicates import predicate
 
 class RuleSet(dict):
     def test_rule(self, name, *args, **kwargs):
-        return name in self and self[name].test(*args, **kwargs)
+        return name in self and self[name]['pred'].test(*args, **kwargs)
 
     def rule_exists(self, name):
         return name in self
 
-    def add_rule(self, name, pred):
+    def rule_verbose_name(self, name):
+        return self[name]['verbose_name'] or name
+
+    def add_rule(self, name, pred, verbose_name=None):
         if name in self:
             raise KeyError("A rule with name `%s` already exists" % name)
-        self[name] = pred
 
-    def set_rule(self, name, pred):
-        self[name] = pred
+        self[name] = {'pred': predicate(pred), 'verbose_name': verbose_name}
+
+    def set_rule(self, name, pred, verbose_name=None):
+        self[name] = {'pred': pred, 'verbose_name': verbose_name}
 
     def remove_rule(self, name):
         del self[name]
 
-    def __setitem__(self, name, pred):
-        fn = predicate(pred)
-        super(RuleSet, self).__setitem__(name, fn)
+    def __setitem__(self, name, pred_dict):
+        super(RuleSet, self).__setitem__(name, pred_dict)
 
 
 # Shared rule set
@@ -29,21 +32,20 @@ class RuleSet(dict):
 default_rules = RuleSet()
 
 
-def add_rule(name, pred):
-    default_rules.add_rule(name, pred)
+def add_rule(name, pred, verbose_name=None):
+    default_rules.add_rule(name, pred, verbose_name=verbose_name)
 
-
-def set_rule(name, pred):
-    default_rules.set_rule(name, pred)
-
+def set_rule(name, pred, verbose_name=None):
+    default_rules.set_rule(name, pred, verbose_name=verbose_name)
 
 def remove_rule(name):
     default_rules.remove_rule(name)
 
-
 def rule_exists(name):
     return default_rules.rule_exists(name)
 
+def rule_verbose_name(name):
+    return default_rules.rule_verbose_name(name)
 
 def test_rule(name, *args, **kwargs):
     return default_rules.test_rule(name, *args, **kwargs)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -18,8 +18,12 @@ class Book(models.Model):
 
 class TestModel(RulesModel):
     class Meta:
-        rules_permissions = {"add": rules.always_true, "view": rules.always_true}
+        rules_permissions = {
+            "add": {'pred': rules.always_true, 'verbose_name': "Add"},
+            "view": rules.always_true,
+        }
 
     @classmethod
     def preprocess_rules_permissions(cls, perms):
-        perms["custom"] = rules.always_true
+        perms["custom"] = {'pred': rules.always_true, 'verbose_name': "Custom Perm"}
+        perms["custom2"] = rules.always_true

--- a/tests/testapp/rules.py
+++ b/tests/testapp/rules.py
@@ -24,8 +24,10 @@ is_editor = rules.is_group_member("editors")
 rules.add_rule("change_book", is_book_author | is_editor)
 rules.add_rule("delete_book", is_book_author)
 rules.add_rule("create_book", is_boss)
+rules.add_rule("borrow_book", is_boss, verbose_name="Borrow the book")
 
 # Permissions
 
 rules.add_perm("testapp.change_book", is_book_author | is_editor)
 rules.add_perm("testapp.delete_book", is_book_author)
+rules.add_perm("testapp.borrow_book", is_boss, verbose_name="Borrow the book")

--- a/tests/testsuite/contrib/test_models.py
+++ b/tests/testsuite/contrib/test_models.py
@@ -9,7 +9,9 @@ import rules
 class RulesModelTests(TestCase):
     def test_preprocess(self):
         self.assertTrue(rules.perm_exists("testapp.add_testmodel"))
+        self.assertTrue(rules.perm_exists("testapp.view_testmodel"))
         self.assertTrue(rules.perm_exists("testapp.custom_testmodel"))
+        self.assertTrue(rules.perm_exists("testapp.custom2_testmodel"))
 
     def test_invalid_config(self):
         from rules.contrib.models import RulesModel

--- a/tests/testsuite/test_permissions.py
+++ b/tests/testsuite/test_permissions.py
@@ -5,6 +5,7 @@ from rules.permissions import (
     add_perm,
     has_perm,
     perm_exists,
+    perm_verbose_name,
     permissions,
     remove_perm,
     set_perm,
@@ -35,6 +36,20 @@ class PermissionsTests(TestCase):
         assert not has_perm("can_edit_book")
         remove_perm("can_edit_book")
         assert not perm_exists("can_edit_book")
+
+    def test_permissions_verbose_name(self):
+        perm_name = "can_shred_book"
+        add_perm(perm_name, always_true, verbose_name="Can this user shred book?")
+        assert perm_exists(perm_name)
+        assert "Can this user shred book?" in perm_verbose_name(perm_name)
+        assert has_perm(perm_name)
+        with self.assertRaises(KeyError):
+            add_perm(perm_name, always_false)
+        set_perm(perm_name, always_false, verbose_name="User cannot shred book!")
+        assert "User cannot shred book!" in perm_verbose_name(perm_name)
+        assert not has_perm(perm_name)
+        remove_perm(perm_name)
+        assert not perm_exists(perm_name)
 
     def test_backend(self):
         backend = ObjectPermissionBackend()

--- a/tests/testsuite/test_rulesets.py
+++ b/tests/testsuite/test_rulesets.py
@@ -7,6 +7,7 @@ from rules.rulesets import (
     default_rules,
     remove_rule,
     rule_exists,
+    rule_verbose_name,
     set_rule,
     test_rule,
 )
@@ -37,12 +38,39 @@ class RulesetTests(TestCase):
         remove_rule("somerule")
         assert not rule_exists("somerule")
 
+    def test_shared_ruleset_verbose(self):
+        add_rule("somerule", always_true, verbose_name="Some Rule which is always true")
+        assert "somerule" in default_rules
+        assert rule_exists("somerule")
+        assert test_rule("somerule")
+        assert "Some Rule which is always true" in rule_verbose_name("somerule")
+        with self.assertRaises(KeyError):
+            add_rule("somerule", always_false)
+        set_rule("somerule", always_false)
+        assert not test_rule("somerule")
+        remove_rule("somerule")
+        assert not rule_exists("somerule")
+
     def test_ruleset(self):
         ruleset = RuleSet()
         ruleset.add_rule("somerule", always_true)
         assert "somerule" in ruleset
         assert ruleset.rule_exists("somerule")
         assert ruleset.test_rule("somerule")
+        with self.assertRaises(KeyError):
+            ruleset.add_rule("somerule", always_true)
+        ruleset.set_rule("somerule", always_false)
+        assert not test_rule("somerule")
+        ruleset.remove_rule("somerule")
+        assert not ruleset.rule_exists("somerule")
+
+    def test_ruleset_verbose(self):
+        ruleset = RuleSet()
+        ruleset.add_rule("somerule", always_true, verbose_name="Some Rule which is always true")
+        assert "somerule" in ruleset
+        assert ruleset.rule_exists("somerule")
+        assert ruleset.test_rule("somerule")
+        assert "Some Rule which is always true" in ruleset.rule_verbose_name("somerule")
         with self.assertRaises(KeyError):
             ruleset.add_rule("somerule", always_true)
         ruleset.set_rule("somerule", always_false)


### PR DESCRIPTION
Adds `verbose_name` for rules and permissions, resolving #59.

This change should be transparent to any existing users of django-rules, but adds the new capability to add and display verbose names for rules & permissions through the use of new/updated RuleSet instance methods and shortcuts for shared and permissions rule sets.

- ``add_rule(name, predicate, verbose_name=None)``: Updated to allow optional `verbose_name`.
- ``set_rule(name, predicate, verbose_name=None)``: Updated to allow optional `verbose_name`
- ``rule_verbose_name(name)``: A new method which returns the ``verbose_name`` if it was supplied when adding or setting the rule. Defaults to ``name`` if no ``verbose_name`` was supplied.
- (similar method names for `permissions`)

Models can now also optionally add verbose names to permissions using the following conventions:

    import rules
    from rules.contrib.models import RulesModel

    class Book(RulesModel):
        class Meta:
            rules_permissions = {
                "add": rules.is_staff,
                "read": {"pred": rules.is_authenticated, "verbose_name": "Can read this book"},
                "delete": {"pred": rules.is_staff},
            }

This would be equivalent to the following calls::

    rules.add_perm("app_label.add_book", rules.is_staff)
    rules.add_perm("app_label.read_book", rules.is_authenticated, verbose_name= "Can read this book")
    rules.add_perm("app_label.delete_book", rules.is_staff)

Tasks:

- [x] Update code
- [x] Add and run tests
- [x] Update Readme

I welcome any feedback.
