### PR TITLE
Update test app to use re_path (url deprecated on Django 4.0)

### DIFF
--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import re_path
 
 from .views import (
     BookCreateView,
@@ -18,40 +18,40 @@ from .views import (
 admin.autodiscover()
 
 urlpatterns = [
-    url(r"^admin/", admin.site.urls),
+    re_path(r"^admin/", admin.site.urls),
     # Function-based views
-    url(r"^(?P<book_id>\d+)/change/$", change_book, name="change_book"),
-    url(r"^(?P<book_id>\d+)/delete/$", delete_book, name="delete_book"),
-    url(r"^(?P<book_id>\d+)/raise/$", view_that_raises, name="view_that_raises"),
-    url(r"^(?P<book_id>\d+)/object/$", view_with_object, name="view_with_object"),
-    url(
+    re_path(r"^(?P<book_id>\d+)/change/$", change_book, name="change_book"),
+    re_path(r"^(?P<book_id>\d+)/delete/$", delete_book, name="delete_book"),
+    re_path(r"^(?P<book_id>\d+)/raise/$", view_that_raises, name="view_that_raises"),
+    re_path(r"^(?P<book_id>\d+)/object/$", view_with_object, name="view_with_object"),
+    re_path(
         r"^(?P<book_id>\d+)/list/$",
         view_with_permission_list,
         name="view_with_permission_list",
     ),
     # Class-based views
-    url(r"^cbv/create/$", BookCreateView.as_view(), name="cbv.create_book"),
-    url(
+    re_path(r"^cbv/create/$", BookCreateView.as_view(), name="cbv.create_book"),
+    re_path(
         r"^cbv/(?P<book_id>\d+)/change/$",
         BookUpdateView.as_view(),
         name="cbv.change_book",
     ),
-    url(
+    re_path(
         r"^cbv/(?P<book_id>\d+)/delete/$",
         BookDeleteView.as_view(),
         name="cbv.delete_book",
     ),
-    url(
+    re_path(
         r"^cbv/(?P<book_id>\d+)/raise/$",
         ViewThatRaises.as_view(),
         name="cbv.view_that_raises",
     ),
-    url(
+    re_path(
         r"^cbv/(?P<book_id>\d+)/list/$",
         ViewWithPermissionList.as_view(),
         name="cbv.view_with_permission_list",
     ),
-    url(
+    re_path(
         r"^cbv/(?P<book_id>\d+)/change-error/$",
         BookUpdateErrorView.as_view(),
         name="cbv.change_book_error",


### PR DESCRIPTION
Tests were failing because Tox tests against `main` archive of Django, which is now on 4.x, and `django.conf.urls.url() is removed.` according to https://docs.djangoproject.com/en/4.0/releases/4.0/
```
[testenv:djangomain]
deps =
    https://github.com/django/django/archive/main.tar.gz#egg=django
    djangorestframework
```

Work towards #152