### PR TITLE
Use APIView.permission_denied to handle 401 and 403 http errors

### DIFF
--- a/rules/contrib/rest_framework.py
+++ b/rules/contrib/rest_framework.py
@@ -72,4 +72,4 @@ class AutoPermissionViewSetMixin:
         # Finally, check permission
         perm = self.get_queryset().model.get_perm(perm_type)
         if not self.request.user.has_perm(perm, obj):
-            raise PermissionDenied
+            self.permission_denied(self.request)


### PR DESCRIPTION
Reference: https://www.django-rest-framework.org/api-guide/authentication/#unauthorized-and-forbidden-responses

I change the test viewset to use BasicAuthentication because the DRF default will always return 403 since the first auth class is SessionAuthentication.