### PR TITLE
Update django 4.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         experimental: [false]
         toxenv: ["py"]
         include:
@@ -38,9 +38,6 @@ jobs:
           - python-version: "3.x"
             toxenv: "djangomain"
             experimental: true
-          - python-version: "pypy-3.9"
-            toxenv: "PyPy"
-            experimental: false
 
     steps:
     - uses: actions/checkout@v3
@@ -60,14 +57,9 @@ jobs:
       run: tox --py current
 
     - name: Run '${{ matrix.toxenv }}' tox targets
-      if: ${{ matrix.toxenv != 'py' && matrix.toxenv != 'PyPy' }}
+      if: ${{ matrix.toxenv != 'py' }}
       continue-on-error: ${{ matrix.experimental }}
       run: tox -e ${{ matrix.toxenv }}
-
-    - name: Run tox targets for Python ${{ matrix.python-version }}
-      if: ${{ matrix.toxenv == 'PyPy' }}
-      continue-on-error: ${{ matrix.experimental }}
-      run: tox -e pypy3-django22,pypy3-django32
 
     - name: Upload coverage data to coveralls.io
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## Unreleased
+
+- Add support for Django 4.1, 4.2
+- Drop support for Django 4.0, 2.2 EOL
+- Drop support for Python 3.7 EOL
+- Drop support for PyPy and PyPy3
+
 ## v3.3.0 - 2022/03/23
 
 - Introduce type annotations for common APIs

--- a/README.rst
+++ b/README.rst
@@ -85,9 +85,8 @@ Table of Contents
 Requirements
 ============
 
-``rules`` requires Python 3.7 or newer. The last version to support Python 2.7
-is ``rules`` 2.2. It can optionally integrate with Django, in which case
-requires Django 2.2 or newer.
+``rules`` requires Python 3.8 or newer. It can optionally integrate with Django, in which case
+requires Django 3.2 or newer.
 
 *Note*: At any given moment in time, ``rules`` will maintain support for all
 currently supported Django versions, while dropping support for those versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py36']
+target-version = ['py38']
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-django{22,32},
-    py{38,39,310}-django40,
+    py{38,39,310}-django{32,40,42},
     packaging,
 
 [testenv]
@@ -9,12 +8,12 @@ usedevelop = true
 deps =
     coverage
     djangorestframework
-    django22: Django~=2.2
     django32: Django~=3.2
-    django40: Django~=4.0
+    django41: Django~=4.1
+    django42: Django~=4.2
 commands =
-    py{37,38,39,310},pypy3: coverage run tests/manage.py test testsuite {posargs: -v 2}
-    py{37,38,39,310},pypy3: coverage report -m
+    py{38,39,310}: coverage run tests/manage.py test testsuite {posargs: -v 2}
+    py{38,39,310}: coverage report -m
 
 [testenv:packaging]
 usedevelop = false


### PR DESCRIPTION
Hi,

I've made this PR that

- Add support for Django 4.1, 4.2
- Drop support for Django 4.0, 2.2 EOL https://www.djangoproject.com/download/#unsupported-versions
- Drop support for Python 3.7 EOL https://devguide.python.org/versions/#unsupported-versions
- Drop support for PyPy and PyPy3 

Can we also have a new release if this PR is merged?

Thanks,

Ref: https://github.com/edx/upgrades/issues/310