### PR TITLE
fix: install py.typed file so mypy will use included type defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## Unreleased
+
+- Fix bug: type annotations were not used because ``py.typed`` was not always
+  installed.
+
 ## v3.3.0 - 2022/03/23
 
 - Introduce type annotations for common APIs

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "rules.templatetags",
         "rules.contrib",
     ],
+    include_package_data=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
I have `rules==3.3` installed from `pypi`, but when I try to run type checks on a project that uses it, `mypy` reports this error:

```
my/project/rules.py:6: error: Skipping analyzing "rules": module is installed, but missing library stubs or py.typed marker  [import]
```

I believe the reason is that the `py.typed` file is not marked as `package_data`, so setuptools is not installing it. I _think_ this should fix it.