### PR TITLE
Add support for Django 4.2, 5.0 and Python 3.11, 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,22 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10"]
+        django-version: ["3.2", "4.2", "5.0"]
         experimental: [false]
-        toxenv: ["py"]
         include:
-          - python-version: "3.x"
-            toxenv: "packaging"
+          - python-version: "3.12"
+            django-version: "packaging"
             experimental: false
-          - python-version: "3.x"
-            toxenv: "djangomain"
+          - python-version: "3.12"
+            django-version: "main"
             experimental: true
-          - python-version: "pypy-3.9"
-            toxenv: "PyPy"
-            experimental: false
+        exclude:
+          # Unsupported Python versions for Django 5.0
+          - python-version: 3.8
+            django-version: 5.0
+          - python-version: 3.9
+            django-version: 5.0
 
     steps:
     - uses: actions/checkout@v3
@@ -52,24 +55,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade coveralls tox tox-py tox-venv
+        python -m pip install --upgrade coveralls tox tox-py tox-venv tox-gh-actions
 
-    - name: Run tox targets for Python ${{ matrix.python-version }}
-      if: ${{ matrix.toxenv == 'py' }}
+    - name: Tox tests
+      run: tox -v
       continue-on-error: ${{ matrix.experimental }}
-      run: tox --py current
-
-    - name: Run '${{ matrix.toxenv }}' tox targets
-      if: ${{ matrix.toxenv != 'py' && matrix.toxenv != 'PyPy' }}
-      continue-on-error: ${{ matrix.experimental }}
-      run: tox -e ${{ matrix.toxenv }}
-
-    - name: Run tox targets for Python ${{ matrix.python-version }}
-      if: ${{ matrix.toxenv == 'PyPy' }}
-      continue-on-error: ${{ matrix.experimental }}
-      run: tox -e pypy3-django22,pypy3-django32
+      env:
+        DJANGO: ${{ matrix.django-version }}
 
     - name: Upload coverage data to coveralls.io
+      if: ${{ matrix.python-version != 'pypy-3.10' }}
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          COVERALLS_FLAG_NAME: run-${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## Unreleased
+
+- Add support for Django 4.2 and 5.0
+- Add support for Python 3.11 and 3.12
+- Drop support for EOL Python 3.7
+- Drop support for EOL Django 2.2 and 4.0
+
 ## v3.3.0 - 2022/03/23
 
 - Introduce type annotations for common APIs

--- a/README.rst
+++ b/README.rst
@@ -85,9 +85,9 @@ Table of Contents
 Requirements
 ============
 
-``rules`` requires Python 3.7 or newer. The last version to support Python 2.7
+``rules`` requires Python 3.8 or newer. The last version to support Python 2.7
 is ``rules`` 2.2. It can optionally integrate with Django, in which case
-requires Django 2.2 or newer.
+requires Django 3.2 or newer.
 
 *Note*: At any given moment in time, ``rules`` will maintain support for all
 currently supported Django versions, while dropping support for those versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py36']
+target-version = ['py38', 'py39', 'py310']
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,10 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,40 @@
 [tox]
 envlist =
-    py{37,38,39,310}-django{22,32},
-    py{38,39,310}-django40,
-    packaging,
+    py{38,39,310,311,312,py3}-dj{32,42}
+    py{310,311,312,py3}-dj{50}
+    py312-packaging
+
+[gh-actions]
+python =
+       3.8: py38
+       3.9: py39
+       3.10: py310
+       3.11: py311
+       3.12: py312
+       pypy-3.10: pypy3
+
+[gh-actions:env]
+DJANGO =
+       3.2: dj32
+       4.2: dj42
+       5.0: dj50
+       main: djmain
+       packaging: packaging
 
 [testenv]
 usedevelop = true
 deps =
     coverage
     djangorestframework
-    django22: Django~=2.2
-    django32: Django~=3.2
-    django40: Django~=4.0
+    dj32: Django~=3.2.0
+    dj42: Django~=4.2.0
+    dj50: Django~=5.0.0
 commands =
-    py{37,38,39,310},pypy3: coverage run tests/manage.py test testsuite {posargs: -v 2}
-    py{37,38,39,310},pypy3: coverage report -m
+    py{38,39,310,311,312}: coverage run tests/manage.py test testsuite {posargs: -v 2}
+    py{38,39,310,311,312}: coverage report -m
+    pypy3: {envpython} tests/manage.py test testsuite {posargs: -v 2}
 
-[testenv:packaging]
+[testenv:py312-packaging]
 usedevelop = false
 deps =
     django
@@ -24,7 +42,7 @@ deps =
 commands =
     {envpython} tests/manage.py test testsuite {posargs: -v 2}
 
-[testenv:djangomain]
+[testenv:py312-djmain]
 deps =
     https://github.com/django/django/archive/main.tar.gz#egg=django
     djangorestframework


### PR DESCRIPTION
Drop support for Django 2.2, 4.0 and Python 3.7

Also simplified the Github actions pipeline using tox-gh-actions.

Coverage for pypy has been disabled due to : https://github.com/nedbat/coveragepy/issues/1382