### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "pypy-3.10"]
         django-version: ["3.2", "4.2", "5.0", "5.1"]
         experimental: [false]
         include:
@@ -40,13 +40,9 @@ jobs:
             experimental: true
         exclude:
           # Unsupported Python versions for Django 5.0
-          - python-version: 3.8
-            django-version: 5.0
           - python-version: 3.9
             django-version: 5.0
           # Unsupported Python versions for Django 5.1
-          - python-version: 3.8
-            django-version: 5.1
           - python-version: 3.9
             django-version: 5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog
 
 *Add a sentence for each interesting change in this section.*
 
+- Drop support for EOL Python 3.8
+
 -------
 
 ## v3.5.0 - 2024/09/02

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Table of Contents
 Requirements
 ============
 
-``rules`` requires Python 3.8 or newer. The last version to support Python 2.7
+``rules`` requires Python 3.9 or newer. The last version to support Python 2.7
 is ``rules`` 2.2. It can optionally integrate with Django, in which case
 requires Django 3.2 or newer.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py39', 'py310']
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    py{38,39,310,311,312,py3}-dj{32,42}
+    py{39,310,311,312,py3}-dj{32,42}
     py{310,311,312,py3}-dj{50,51}
     py312-packaging
 
 [gh-actions]
 python =
-       3.8: py38
        3.9: py39
        3.10: py310
        3.11: py311
@@ -32,8 +31,8 @@ deps =
     dj50: Django~=5.0.0
     dj51: Django~=5.1.0
 commands =
-    py{38,39,310,311,312}: coverage run tests/manage.py test testsuite {posargs: -v 2}
-    py{38,39,310,311,312}: coverage report -m
+    py{39,310,311,312}: coverage run tests/manage.py test testsuite {posargs: -v 2}
+    py{39,310,311,312}: coverage report -m
     pypy3: {envpython} tests/manage.py test testsuite {posargs: -v 2}
 
 [testenv:py312-packaging]


### PR DESCRIPTION
Python 3.8 reached EOL in October 2024 https://discuss.python.org/t/python-3-8-is-now-officially-eol/66983 .