### PR TITLE
Drop Django 3.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10"]
-        django-version: ["3.2", "4.2", "5.0", "5.1"]
+        django-version: ["4.2", "5.0", "5.1"]
         experimental: [false]
         include:
           - python-version: "3.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog
 
 *Add a sentence for each interesting change in this section.*
 
+- Drop support for EOL Django 3.2
+
 -------
 
 ## v3.5.0 - 2024/09/02

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312,py3}-dj{32,42}
+    py{38,39,310,311,312,py3}-dj{42}
     py{310,311,312,py3}-dj{50,51}
     py312-packaging
 
@@ -15,7 +15,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-       3.2: dj32
        4.2: dj42
        5.0: dj50
        5.1: dj51
@@ -27,7 +26,6 @@ usedevelop = true
 deps =
     coverage
     djangorestframework
-    dj32: Django~=3.2.0
     dj42: Django~=4.2.0
     dj50: Django~=5.0.0
     dj51: Django~=5.1.0


### PR DESCRIPTION
Django 3.2 reached EOL in April 2024 https://www.djangoproject.com/download/ .