### PR TITLE
Support async backend methods

### DIFF
--- a/rules/permissions.py
+++ b/rules/permissions.py
@@ -1,4 +1,5 @@
 from asgiref.sync import sync_to_async
+
 from .rulesets import RuleSet
 
 permissions = RuleSet()

--- a/rules/permissions.py
+++ b/rules/permissions.py
@@ -1,11 +1,11 @@
 from .rulesets import RuleSet
 
-
 permissions = RuleSet()
 
 
 async def _run_async(func, *args, **kwargs):
     from asgiref.sync import sync_to_async
+
     return await sync_to_async(func)(*args, **kwargs)
 
 

--- a/rules/permissions.py
+++ b/rules/permissions.py
@@ -39,6 +39,9 @@ class ObjectPermissionBackend(object):
     def has_module_perms(self, user, app_label):
         return has_perm(app_label, user)
 
+    async def aauthenticate(self, *args, **kwargs):
+        return None
+
     async def ahas_perm(self, user, perm, *args, **kwargs):
         return await _run_async(has_perm, user, perm, *args, **kwargs)
 

--- a/rules/permissions.py
+++ b/rules/permissions.py
@@ -1,8 +1,12 @@
-from asgiref.sync import sync_to_async
-
 from .rulesets import RuleSet
 
+
 permissions = RuleSet()
+
+
+async def _run_async(func, *args, **kwargs):
+    from asgiref.sync import sync_to_async
+    return await sync_to_async(func)(*args, **kwargs)
 
 
 def add_perm(name, pred):
@@ -36,7 +40,7 @@ class ObjectPermissionBackend(object):
         return has_perm(app_label, user)
 
     async def ahas_perm(self, user, perm, *args, **kwargs):
-        return await sync_to_async(has_perm)(user, perm, *args, **kwargs)
+        return await _run_async(has_perm, user, perm, *args, **kwargs)
 
     async def ahas_module_perms(self, user, app_label):
-        return await sync_to_async(has_perm)(app_label, user)
+        return await _run_async(has_perm, app_label, user)

--- a/rules/permissions.py
+++ b/rules/permissions.py
@@ -1,3 +1,4 @@
+from asgiref.sync import sync_to_async
 from .rulesets import RuleSet
 
 permissions = RuleSet()
@@ -32,3 +33,9 @@ class ObjectPermissionBackend(object):
 
     def has_module_perms(self, user, app_label):
         return has_perm(app_label, user)
+
+    async def ahas_perm(self, user, perm, *args, **kwargs):
+        return await sync_to_async(has_perm)(user, perm, *args, **kwargs)
+
+    async def ahas_module_perms(self, user, app_label):
+        return await sync_to_async(has_perm)(app_label, user)

--- a/tests/testsuite/test_permissions.py
+++ b/tests/testsuite/test_permissions.py
@@ -1,5 +1,6 @@
-from asgiref.sync import sync_to_async
 from unittest import TestCase
+
+from asgiref.sync import sync_to_async
 
 from rules.permissions import (
     ObjectPermissionBackend,

--- a/tests/testsuite/test_permissions.py
+++ b/tests/testsuite/test_permissions.py
@@ -1,3 +1,4 @@
+from asgiref.sync import sync_to_async
 from unittest import TestCase
 
 from rules.permissions import (
@@ -50,3 +51,17 @@ class PermissionsTests(TestCase):
         assert not backend.has_perm(None, "can_edit_book")
         remove_perm("can_edit_book")
         assert not perm_exists("can_edit_book")
+
+    async def test_backend_async(self):
+        backend = ObjectPermissionBackend()
+
+        await sync_to_async(add_perm)("can_edit_book", always_true)
+        assert "can_edit_book" in permissions
+        assert await backend.ahas_perm(None, "can_edit_book")
+        assert await backend.ahas_module_perms(None, "can_edit_book")
+        with self.assertRaises(KeyError):
+            await sync_to_async(add_perm)("can_edit_book", always_true)
+        await sync_to_async(set_perm)("can_edit_book", always_false)
+        assert not await backend.ahas_perm(None, "can_edit_book")
+        await sync_to_async(remove_perm)("can_edit_book")
+        assert not await sync_to_async(perm_exists)("can_edit_book")


### PR DESCRIPTION
This PR adds two new methods to the `ObjectPermissionsBackend` class, to support async environments: `ahas_perm` and `ahas_module_perms`. These implementations just wrap the original sync versions in `sync_to_async`, which comes from `asgiref` (and should be included in all currently supported versions of Django). 

Resolves #199.

This PR used #197 as a base, so that PR should probably be merged before this one.