### PR TITLE
Add Django as an install dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10"]
-        django-version: ["3.2", "4.2", "5.0", "5.1"]
+        django-version: ["3.2", "4.2", "5.0", "5.1", "5.2"]
         experimental: [false]
         include:
           - python-version: "3.12"
@@ -49,6 +49,11 @@ jobs:
             django-version: 5.1
           - python-version: 3.9
             django-version: 5.1
+          # Unsupported Python versions for Django 5.2
+          - python-version: 3.8
+            django-version: 5.2
+          - python-version: 3.9
+            django-version: 5.2
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - uses: pre-commit/action@v2.0.2
+      - uses: pre-commit/action@v3.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog
 
 *Add a sentence for each interesting change in this section.*
 
+- Add support for Django 5.2
+
 -------
 
 ## v3.5.0 - 2024/09/02

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,7 @@ setup(
         "rules.templatetags",
         "rules.contrib",
     ],
-    install_requires=[
-        "Django>=3.2"
-    ],
+    install_requires=["Django>=3.2"],
     include_package_data=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setup(
         "rules.templatetags",
         "rules.contrib",
     ],
+    install_requires=[
+        "Django>=3.2"
+    ],
     include_package_data=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{38,39,310,311,312,py3}-dj{32,42}
-    py{310,311,312,py3}-dj{50,51}
+    py{310,311,312,py3}-dj{50,51,52}
     py312-packaging
 
 [gh-actions]
@@ -19,6 +19,7 @@ DJANGO =
        4.2: dj42
        5.0: dj50
        5.1: dj51
+       5.2: dj52
        main: djmain
        packaging: packaging
 
@@ -31,6 +32,7 @@ deps =
     dj42: Django~=4.2.0
     dj50: Django~=5.0.0
     dj51: Django~=5.1.0
+    dj52: Django~=5.2.0
 commands =
     py{38,39,310,311,312}: coverage run tests/manage.py test testsuite {posargs: -v 2}
     py{38,39,310,311,312}: coverage report -m


### PR DESCRIPTION
This PR adds Django as an install dependency for `rules`. Based on what is currently being covered in tests, this will require at least Django version 3.2.

This PR used https://github.com/dfunckt/django-rules/pull/197 as a base.